### PR TITLE
fix: support repository with dot or hyphen

### DIFF
--- a/src/generateIgnoreFile.js
+++ b/src/generateIgnoreFile.js
@@ -12,7 +12,7 @@ import highlightComments from './utils/highlightComments.js'
 import joinLinesWithEOF from './utils/joinLinesWithEOF.js'
 import { dynamicComposeP, promiseMap } from './utils/ramdaHelper.js'
 
-const isGithubSource = R.test(/^(\w+\/\w+)$/i)
+const isGithubSource = R.test(/^([\w.-]+\/[\w.-]+)$/i)
 const prependAlert = R.concat([highlightComments(COMMENT_HEADER_ALERT), ''])
 const sourceIs = (...args) => R.compose(...args, R.prop('source'))
 


### PR DESCRIPTION
Some GitHub repositories with `.` or `-`, like `vercel/next.js`, were not supported.
