### PR TITLE
fix: use default branch instead of master

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ corepack enable
        packages/a/ignored.md
        ```
 
-   - `[$username/$repo]`
+   - `[$username/$repo#$ref]`
      - the content of these github files will be downloaded and appended to generated ignore file
      - recommend using ignore patterns from [[github/gitignore]](https://github.com/github/gitignore)
+     - `$ref` is optional, default to the default branch
 
 1. `npm run ignore-sync`

--- a/src/cleanupIgnoreSyncFile.js
+++ b/src/cleanupIgnoreSyncFile.js
@@ -3,9 +3,10 @@ import * as R from 'ramda'
 import { COMMENT_CHAR, LINE_BREAK } from './constants.js'
 
 const removeEmptyLines = R.reject((line) => line === '')
-const removeTrailingSpacesAndComment = R.replace(
-  new RegExp(`\\s*(${COMMENT_CHAR}.*)?$`),
-  '',
+const removeTrailingSpacesAndComment = R.ifElse(
+  R.test(/^\[(.*)\]/),
+  R.replace(new RegExp(`].*$`), ']'),
+  R.replace(new RegExp(`\\s*(${COMMENT_CHAR}.*)?$`), ''),
 )
 
 const cleanupIgnoreSyncFile = R.compose(

--- a/src/cleanupIgnoreSyncFile.test.js
+++ b/src/cleanupIgnoreSyncFile.test.js
@@ -14,6 +14,16 @@ describe('cleanupIgnoreSyncFile', () => {
     expect(cleanupIgnoreSyncFile('pattern   #')).toBe('pattern')
   })
 
+  test('should not remove comments inside source tags', () => {
+    expect(cleanupIgnoreSyncFile('[owner/repo#ref]')).toBe('[owner/repo#ref]')
+    expect(cleanupIgnoreSyncFile('[owner/repo#ref] # comment')).toBe(
+      '[owner/repo#ref]',
+    )
+    expect(cleanupIgnoreSyncFile('[owner/repo#ref]   ')).toBe(
+      '[owner/repo#ref]',
+    )
+  })
+
   test('should remove empty lines', () => {
     expect(cleanupIgnoreSyncFile('\n\n\npat\n\n\ntern\n\n\n')).toBe('pat\ntern')
   })

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -1,11 +1,23 @@
 import axios from 'axios'
+import * as R from 'ramda'
+
+const getDefaultBranch = R.memoizeWith(
+  ({ owner, repo }) => `${owner}/${repo}`,
+  async ({ owner, repo }) => {
+    const { data: repoData } = await axios.get(
+      `https://api.github.com/repos/${owner}/${repo}`,
+    )
+    return repoData.default_branch
+  },
+)
 
 export const getGitHubContentFile = async ({
   owner,
-  path,
-  ref = 'master', // commit/branch/tag
   repo,
+  ref, // commit/branch/tag
+  path,
 }) => {
+  ref = ref ?? (await getDefaultBranch({ owner, repo }))
   const { data: file } = await axios.get(
     `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${path}`,
   )


### PR DESCRIPTION
Closes #680

Uses the default branch of the repo retrieved from GitHub API instead of `master`.

Also adds support for specifying a commit/branch/tag with the syntax of #ref.

However, the API has a rate limit of 60 requests/hour. I used memoization to reduce requests, but if a user uses many repositories as a source or runs ignore-sync many times, the request might fail.

---

I skipped the `jest` pre-commit check since it didn't work with an error, "Validation Error: Preset @foray1010 not found."